### PR TITLE
Exceptions in vnx::File

### DIFF
--- a/src/File.cpp
+++ b/src/File.cpp
@@ -33,7 +33,11 @@ File::File(const std::string& path_) : File() {
 }
 
 File::~File() {
-	close();
+	try{
+		close();
+	}catch(...){
+		// no exceptions in destructors
+	}
 }
 
 void File::open(const std::string& path_, const std::string& mode) {

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -202,12 +202,13 @@ void File::close() {
 	if(p_file) {
 		out.flush();
 		unlock();
-		if(::fclose(p_file)) {
-			throw std::runtime_error("fclose('" + path + "') failed with: " + std::string(::strerror(errno)));
-		}
+		const auto error = ::fclose(p_file);
 		p_file = nullptr;
 		stream_in.reset(nullptr);
 		stream_out.reset(nullptr);
+		if(error) {
+			throw std::runtime_error("fclose('" + path + "') failed with: " + std::string(::strerror(errno)));
+		}
 	}
 }
 


### PR DESCRIPTION
This addresses two issues.

#### Always drop file pointer on `fclose()`

Cf. https://en.cppreference.com/w/c/io/fclose:

> Whether or not the operation succeeds, the stream is no longer associated with a file [...]. The behavior is undefined if the value of the pointer `stream` is used after `fclose` returns.

If `fclose()` fails here, the destructor will later attempt to call it again. We have a confirmed case on file where this caused a crash with SIGABRT.

Also, I don't see anything in the docs about `fclose()` setting the `errno`, but I haven't confirmed.

#### No exceptions in destructors

Cf. https://en.cppreference.com/w/cpp/language/destructor#Exceptions:

> As any other function, a destructor may terminate by throwing an exception (this usually requires it to be explicitly declared `noexcept(false)`), however if this destructor happens to be called during stack unwinding, `std::terminate` is called instead. [...] [I]t is generally considered bad practice to allow any destructor to terminate by throwing an exception.

Definitely relevant for this class.