### PR TITLE
64 bits file offset type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 if(NOT WIN32)
 	add_compile_options(-Wall)
 endif()
+if(NOT MSVC)
+	add_compile_options(-D _FILE_OFFSET_BITS=64)
+endif()
 
 find_package(Threads REQUIRED)
 

--- a/include/vnx/Util.h
+++ b/include/vnx/Util.h
@@ -65,7 +65,7 @@ inline int fseek(FILE* stream, int64_t offset, int whence)
 #ifdef _MSC_VER
 	return ::_fseeki64(stream, offset, whence);
 #else
-	return ::fseek(stream, offset, whence);
+	return ::fseeko(stream, offset, whence);
 #endif
 }
 


### PR DESCRIPTION
`ftello()` and `fseeko()` functions use `off_t` as index type. By default it equals `long` which is 4 bytes on some platforms, restricting file size to 2 GiB. The compiler flag `_FILE_OFFSET_BITS=64` turns `off_t` into an 8 bytes type. See https://linux.die.net/man/3/ftello.
(I also changed one use of `fseek()`, which always uses `long`.)

Affected systems:
* 32 bit Linux
* MinGW (because it follows the [Windows convention](https://learn.microsoft.com/en-us/cpp/cpp/fundamental-types-cpp?view=msvc-170#sizes-of-built-in-types))

As far as I can see, everything else either uses different seek functions (MSVC) or has a convention of 8 byte `long` (64 bit Linux, MacOS), but even in that case the flag doesn't hurt.