### PR TITLE
Read non-native enum values

### DIFF
--- a/src/Type.cpp
+++ b/src/Type.cpp
@@ -695,9 +695,9 @@ void TypeCode::print(std::ostream& out) const {
 		out << "enum " << name << " {";
 		int i = 0;
 		for(const auto& entry : enum_map) {
-			out << entry.second << (i++ ? "," : "") << std::endl;
+			out << (i++ ? "," : "") << std::endl << entry.second;
 		}
-		out << "}" << std::endl;
+		out << std::endl << "}" << std::endl;
 	} else {
 		out << (is_class ? "class " : "struct ") << name << " {" << std::endl;
 		for(const auto& field : fields) {

--- a/src/Value.cpp
+++ b/src/Value.cpp
@@ -413,6 +413,9 @@ void accept(Visitor& visitor, TypeInput& in, const TypeCode* type_code, const ui
 			if(const auto* const _field = type_code->field_map[0]) {
 				vnx::read_value(buf.data() + _field->offset, value, _field->code.data());
 			}
+		}else if(!type_code->is_matched && type_code->fields.size() > 0){
+			const auto& _field = type_code->fields[0];
+			vnx::read_value(buf.data() + _field.offset, value, _field.code.data());
 		}
 		auto iter = type_code->enum_map.find(value);
 		if(iter != type_code->enum_map.end()) {


### PR DESCRIPTION
Fixes deserialization of non-native enum values which are read/printed as 0 at the moment.

Before:
```
$ vnxread -f localization.status.dat
{
  "__type": "pilot.LocalizationStatus",
  "time": 1747399259350479,
  "mode": 0,
  "sensors": ["lidar_1", "lidar_2"],
  [...]
}
```
After:
```
$ vnxread -f localization.status.dat
{
  "__type": "pilot.LocalizationStatus",
  "time": 1747399259350479,
  "mode": "MODE_2D_YAW",
  "sensors": ["lidar_1", "lidar_2"],
  [...]
}
```

As far as I understand, the `field_map` is only filled for native types and its main purpose is alias mapping which is probably irrelevant for enums. But I'm not sure, correct me if I'm wrong.

I also found a minor output formatting bug along the way.